### PR TITLE
use invariant formatter for teleport coords

### DIFF
--- a/LarkatorGUI/MainWindow.xaml.cs
+++ b/LarkatorGUI/MainWindow.xaml.cs
@@ -439,7 +439,7 @@ namespace LarkatorGUI
             {
                 var z = dvm.Dino.Location.Z + Properties.Settings.Default.TeleportHeightOffset;
                 var clipboard = "cheat SetPlayerPos ";
-                clipboard += $"{dvm.Dino.Location.X:0.00} {dvm.Dino.Location.Y:0.00} {z:0.00}";
+                clipboard += System.FormattableString.Invariant($"{dvm.Dino.Location.X:0.00} {dvm.Dino.Location.Y:0.00} {z:0.00}");
                 if (Properties.Settings.Default.TeleportFly)
                 {
                     clipboard += " | cheat fly";


### PR DESCRIPTION
in order to be used in ark console, number should be formatted in invariant format.